### PR TITLE
Fix: Resolve NameError for List in gui.py type hints

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -3,6 +3,7 @@ import threading
 import tkinter as tk
 import queue
 from tkinter import ttk, messagebox, simpledialog
+from typing import List # Added for type hinting
 from trading import Trader  # adjust import path if needed
 from strategies import (
     SafeStrategy, ModerateStrategy, AggressiveStrategy,


### PR DESCRIPTION
- Added `from typing import List` to gui.py to correctly define the List type hint used in the `populate_symbols_dropdown` method signature.

This commit also includes the previous feature:
Feat: Populate GUI symbol dropdown dynamically from API

- Modified Trader class to add `get_available_symbol_names()` method.
- Removed hardcoded `COMMON_PAIRS` from `TradingPage`.
- `TradingPage.__init__` now initializes the symbol Combobox as empty.
- Implemented `TradingPage.populate_symbols_dropdown()` to update the Combobox values with symbols from the Trader and select the default.
- Modified `SettingsPage._on_successful_connection()` to call `populate_symbols_dropdown()`.

## Summary by Sourcery

Fix a NameError in gui.py by importing missing List and implement a dynamic symbol dropdown in the trading GUI driven by API data

New Features:
- Populate the trading GUI's symbol dropdown dynamically from API data

Bug Fixes:
- Import List in gui.py to resolve NameError in type hints

Enhancements:
- Add Trader.get_available_symbol_names() method to retrieve symbols
- Remove hardcoded COMMON_PAIRS and initialize the TradingPage symbol Combobox as empty
- Invoke populate_symbols_dropdown() upon successful connection in SettingsPage