### PR TITLE
Fix: Add ctidTraderAccountId to ProtoOASymbolByIdReq

### DIFF
--- a/trading.py
+++ b/trading.py
@@ -442,7 +442,11 @@ class Trader:
         print(f"Requesting full symbol details for IDs: {symbol_ids}")
         req = ProtoOASymbolByIdReq()
         req.symbolId.extend(symbol_ids)
-        # req.ctidTraderAccountId = self.ctid_trader_account_id # Not required for this message type
+        if not self.ctid_trader_account_id:
+            self._last_error = "Cannot get symbol details: ctidTraderAccountId is not set."
+            print(self._last_error)
+            return
+        req.ctidTraderAccountId = self.ctid_trader_account_id
 
         print(f"Sending ProtoOASymbolByIdReq: {req}")
         try:


### PR DESCRIPTION
- Modified `_send_get_symbol_details_request` in `trading.py` to include the `ctidTraderAccountId` field in the `ProtoOASymbolByIdReq` message.
- This resolves the `google.protobuf.message.EncodeError` which occurred because this required field was previously missing.
- Added a check to ensure `ctidTraderAccountId` is available before attempting to send the request.