### PR TITLE
Fix: Pin NumPy to ~1.26.0 for pandas-ta compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,5 @@ requests
 
 # For data manipulation and technical indicators
 pandas
+numpy~=1.26.0 # Pin numpy to a version likely compatible with pandas-ta's NaN import
 pandas-ta


### PR DESCRIPTION
- Updated requirements.txt to specify `numpy~=1.26.0`.
- This resolves an ImportError (`cannot import name 'NaN' from 'numpy'`) that occurred when using pandas-ta 0.3.14b0 with NumPy 2.x versions. NumPy 1.26.4 is now installed and resolves this specific import issue.

## Summary by Sourcery

Pin NumPy to ~1.26.0 in requirements to restore compatibility with pandas-ta and fix the NaN import error

Bug Fixes:
- Resolve ImportError for 'NaN' import from NumPy when using pandas-ta with NumPy 2.x

Build:
- Pin NumPy dependency in requirements.txt to ~1.26.0